### PR TITLE
Improve Skip confirmation message

### DIFF
--- a/app/src/main/java/com/adam/aslfms/PermissionsActivity.java
+++ b/app/src/main/java/com/adam/aslfms/PermissionsActivity.java
@@ -222,8 +222,8 @@ public class PermissionsActivity extends AppCompatActivity {
             AlertDialog.Builder builder = new AlertDialog.Builder(context);
             String message = context.getResources().getString(R.string.warning) + "! " + context.getResources().getString(R.string.are_you_sure);
             if (Build.VERSION_CODES.O <= Build.VERSION.SDK_INT && !Util.checkNotificationListenerPermission(context)) {
-                message += " - " + context.getResources().getString(R.string.warning_will_not_scrobble);
-                message += " - " + context.getResources().getString(R.string.permission_notification_listener);
+                message += " " + context.getResources().getString(R.string.scrobble_will_not_work_properly);
+                message += " - " + context.getResources().getString(R.string.notification_access_recommended);
             }
             builder.setMessage(message).setPositiveButton(R.string.yes, dialogClickListener)
                     .setNegativeButton(R.string.no, dialogClickListener).show();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,6 +121,7 @@
     <string name="permission_required">Permission REQUIRED to work properly</string>
     <string name="creds_required">Credentials REQUIRED to work properly</string>
     <string name="notification_access_required">Notification access REQUIRED to work properly</string>
+    <string name="notification_access_recommended">Notification access is strongly recommended to make scrobble work.</string>
     <string name="limited_network">Limited Network</string>
     <!-- END permissions and warnings strings -->
     <!-- START mapis strings -->
@@ -244,6 +245,7 @@
     <string name="find_battery_settings">Find Battery Optimization ignore list in Android Settings, add Simple Scrobbler</string>
     <string name="permission_notification_listener_notice">Enable Notifications Access for Simple Scrobbler in Android Settings</string>
     <string name="warning_will_not_scrobble">Warning will not Scrobble</string>
+    <string name="scrobble_will_not_work_properly">Scrobble will not work properly</string>
     <!-- END permissions activity -->
     <!-- START correction rules strings -->
     <string name="old_track">Track Title</string>


### PR DESCRIPTION
Before this patch, the confirmation message had the 'warning' word duplicated.
Now, the message was rewritten to give better information to the user about the skip action.