### PR TITLE
Improve explanation for "Active App Notification" setting

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,7 +142,7 @@
     <!-- END mapis strings -->
     <!-- START options_prefs strings -->
     <string name="active_app">Persistent Notification</string>
-    <string name="active_app_summary">If you turn this off then ensure battery optimisations are enabled.</string>
+    <string name="active_app_summary">If you turn this off then ensure battery optimizations are enabled.</string>
     <string name="options_title">Options</string>
     <string name="advanced_options_title">Advanced options</string>
     <string name="scrobbling">Scrobble</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,7 +142,7 @@
     <!-- END mapis strings -->
     <!-- START options_prefs strings -->
     <string name="active_app">Persistent Notification</string>
-    <string name="active_app_summary">If you turn this off then ensure battery optimisations are disabled.</string>
+    <string name="active_app_summary">If you turn this off then ensure battery optimisations are enabled.</string>
     <string name="options_title">Options</string>
     <string name="advanced_options_title">Advanced options</string>
     <string name="scrobbling">Scrobble</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,8 +141,8 @@
     <!-- TODO: Translate -->
     <!-- END mapis strings -->
     <!-- START options_prefs strings -->
-    <string name="active_app">Active App Notification</string>
-    <string name="active_app_summary">WARNING, may skip scrobbles.</string>
+    <string name="active_app">Persistent Notification</string>
+    <string name="active_app_summary">If you turn this off then ensure battery optimisations are disabled.</string>
     <string name="options_title">Options</string>
     <string name="advanced_options_title">Advanced options</string>
     <string name="scrobbling">Scrobble</string>


### PR DESCRIPTION
For me, it wasn't immediately 100% obvious that this setting controlled the persistent notification.

Also, the warning message was discouraging me from trying out the setting as I do not want to skip scrobbles, though I found out later that the warning is for when battery optimisations are not disabled for the app.

Hence rewrote both to make it more clear.